### PR TITLE
Update pra1_informe.Rmd

### DIFF
--- a/informe/pra1_informe.Rmd
+++ b/informe/pra1_informe.Rmd
@@ -153,7 +153,7 @@ A lo largo del proyecto, los autores nos hemos enfrentado a una serie de problem
 
 ## Dataset
 
-El dataset ha sido publicado en Zenodo con DOI...
+El dataset ha sido publicado en Zenodo con DOI 10.5281/zenodo.4263268
 
 ## Contribuciones
 


### PR DESCRIPTION
Incluido el DOI y publicado ya en Zenodo. Te dejo a ti la creación final del pdf a partir del Rmd si te parece bien.

Sólo un detalle menor del que me acabo de dar cuenta una vez publicado el archivo: en la variable rendimiento en vez del valor que aparece en la web como porcentaje de victorias, lo que está calculado en nuestro caso es la fracción de victorias, por si quieres dejarlo explicitado en el informe.